### PR TITLE
fix: converter/programmer menus, when you open these menus along with…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 ## Errors
 - [ ] line 890 error in Bit shift, Rotate Through Carry! - Programmer calc
 - [ ] Rotate Through Carry. - Programmer calc
+- [x] converter/programmer menus, when you open these menus along with the mode selection menu, they end up being on top of the mode selection menu.
 
 
 ### Next tasks

--- a/assets/css/Index.css
+++ b/assets/css/Index.css
@@ -182,7 +182,7 @@ body{
     min-width: 100%;
     min-height: 100%;
     position: absolute;
-    z-index: 97;
+    z-index: 96;
     right: 0;
 
 }
@@ -485,7 +485,7 @@ body{
     align-items: center;
     flex-wrap: wrap;
     justify-content: space-around;
-    z-index: 98;
+    z-index: 97;
     outline: solid .1rem black;
 
 }
@@ -512,7 +512,7 @@ body{
     flex-direction: column;
     align-items: center;
     justify-content: space-around;
-    z-index: 98;
+    z-index: 97;
     outline: solid .1rem black;
 
 }
@@ -708,7 +708,7 @@ body{
     overflow-x: hidden;
     overflow-y: auto;
     right: -10%;
-    z-index: 98;
+    z-index: 97;
     display: flex;
     flex-direction: column;
     justify-content: flex-start;


### PR DESCRIPTION
… the mode selection menu, they end up being on top of the mode selection menu.